### PR TITLE
Add frame counter to slow animations

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -3,6 +3,7 @@
 
 .segment "ZEROPAGE"
 frame_index: .res 1
+frame_counter: .res 1
 
 .segment "CODE"
 .proc irq_handler
@@ -118,15 +119,23 @@ vblankwait:                         ; wait for another vblank before continuing
 
     LDA #$00
     STA frame_index
+    STA frame_counter
     JSR set_chr_banks
 
 forever:
     BIT PPUSTATUS
     BPL forever
+    INC frame_counter
+    LDA frame_counter
+    CMP #$3C
+    BCC no_change
+    LDA #$00
+    STA frame_counter
     LDA frame_index
     EOR #$01
     STA frame_index
     JSR set_chr_banks
+no_change:
     JMP forever
 .endproc
 


### PR DESCRIPTION
## Summary
- slow frame changes by counting vblanks

## Testing
- `../cc65/bin/ca65 src/main.asm && ../cc65/bin/ca65 src/reset.asm && ../cc65/bin/ca65 src/background.asm && ../cc65/bin/ld65 src/reset.o src/main.o src/background.o -C nes.cfg -o display.nes` *(fails: memory area overflow)*

------
https://chatgpt.com/codex/tasks/task_e_684c009350a083298f0defca53d72210